### PR TITLE
Add utility class for runtime permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MusicMap"
+        android:name="com.example.musicmap.MusicMap"
         tools:targetApi="31">
         <activity
             android:name=".screens.main.ProfileActivity"

--- a/app/src/main/java/com/example/musicmap/MusicMap.java
+++ b/app/src/main/java/com/example/musicmap/MusicMap.java
@@ -1,0 +1,27 @@
+package com.example.musicmap;
+
+import android.app.Application;
+
+/**
+ * The main Application.
+ */
+public class MusicMap extends Application {
+
+    private static MusicMap instance;
+
+    /**
+     * Gets the instance of this application.
+     *
+     * @return the instance.
+     */
+    public static MusicMap getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        instance = this;
+    }
+
+}

--- a/app/src/main/java/com/example/musicmap/screens/map/MapFragment.java
+++ b/app/src/main/java/com/example/musicmap/screens/map/MapFragment.java
@@ -1,9 +1,7 @@
 package com.example.musicmap.screens.map;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -18,6 +16,7 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.example.musicmap.R;
+import com.example.musicmap.util.Permission;
 
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
@@ -34,8 +33,7 @@ public class MapFragment extends Fragment {
 
     private static final String MULTITOUCH_FEATURE = "android.hardware.touchscreen.multitouch";
 
-    private static final int PERMISSION_ACCESS_FINE_LOCATION_REQUEST_CODE = 1;
-    private static final int PERMISSION_ACCESS_COARSE_LOCATION_REQUEST_CODE = 2;
+    private final Permission.Location locationPermission = new Permission.Location(this);
 
     /**
      * The MapView used by this fragment.
@@ -68,29 +66,15 @@ public class MapFragment extends Fragment {
         Context ctx = activity.getApplicationContext();
         Configuration.getInstance().load(ctx, PreferenceManager.getDefaultSharedPreferences(ctx));
 
-        // Request needed permissions if applicable
-        // TODO message explaining the permissions,
-        //  see https://developer.android.com/training/permissions/requesting#explain
-        //  check if permissions were granted, check if the app can function without these permission
-        //  probably do permissions elsewhere
-        if (activity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-            // Request coarse location access permission
-            activity.requestPermissions(new String[] {Manifest.permission.ACCESS_COARSE_LOCATION},
-                    PERMISSION_ACCESS_COARSE_LOCATION_REQUEST_CODE);
-        }
-        if (activity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-            // Request fine location access permission
-            activity.requestPermissions(new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
-                    PERMISSION_ACCESS_FINE_LOCATION_REQUEST_CODE);
-        }
+        // Request needed permissions if needed
+        locationPermission.request();
 
         View rootView = inflater.inflate(R.layout.fragment_map, container, false);
 
         mapView = rootView.findViewById(R.id.map);
         mapView.setTileSource(TileSourceFactory.MAPNIK); // the default OSM tile source (data source)
 
+        // Set zoom buttons location
         mapView.getZoomController().getDisplay().setPositions(false,
                 CustomZoomButtonsDisplay.HorizontalPosition.RIGHT,
                 CustomZoomButtonsDisplay.VerticalPosition.CENTER);
@@ -150,10 +134,18 @@ public class MapFragment extends Fragment {
      * using {@link #addOverlay(Overlay)}.
      */
     protected void addOverlays() {
+        if (!mapView.getOverlayManager().overlays().isEmpty()) {
+            throw new IllegalStateException("Attempted to add overlays twice");
+        }
+
         // Default overlay showing current location (only if needed)
         if (shouldDisplayCurrentLocation()) {
+            if (locationPermission.isNoneGranted()) {
+                return;
+            }
+
             CurrentLocationOverlay currentLocationOverlay = new CurrentLocationOverlay(mapView);
-            mapView.getOverlayManager().add(0, currentLocationOverlay);
+            addOverlay(currentLocationOverlay);
         }
     }
 

--- a/app/src/main/java/com/example/musicmap/util/Permission.java
+++ b/app/src/main/java/com/example/musicmap/util/Permission.java
@@ -52,7 +52,7 @@ public abstract class Permission {
 
     protected abstract String[] getAndroidPermissions();
 
-    protected void onActivityResult(Map<String, Boolean> permissions) {
+    private void onActivityResult(Map<String, Boolean> permissions) {
         onChangeListeners.forEach(Runnable::run);
     }
 
@@ -64,7 +64,7 @@ public abstract class Permission {
      *
      * @return the permission grant map.
      */
-    protected Map<String, Boolean> getPermissionGrantMap() {
+    protected final Map<String, Boolean> getPermissionGrantMap() {
         // Gets the context
         Context context = MusicMap.getInstance().getApplicationContext();
 
@@ -83,20 +83,33 @@ public abstract class Permission {
     /**
      * Requests this permission.
      *
-     * Feel free to use even if the permission has already been granted.
+     * Feel free to use even if the permission has already been granted:
+     * the user will only receive the request once.
+     *
+     * @see #forceRequest()
      */
     public void request() {
-        Log.i("MM-Permission", "Requested " + getClass().getSimpleName());
-
         // Check if permissions were requested before
         if (!sharedPreferences.getBoolean(SHARED_PREFERENCES_KEY, false)) {
-            this.launcher.launch(getAndroidPermissions());
-
-            // Store the request in the SharedPreferences
-            SharedPreferences.Editor editor = sharedPreferences.edit();
-            editor.putBoolean(SHARED_PREFERENCES_KEY, true);
-            editor.apply();
+            forceRequest();
         }
+    }
+
+    /**
+     * Requests this permissions. This will not check if the permission was requested before.
+     *
+     * Use this over {@link #request()} in case the action causing the request
+     * is directly linked to the permission, e.g. a button 'take picture' is directly linked to camera permissions.
+     */
+    public void forceRequest() {
+        Log.i("MM-Permission", "Requested " + getClass().getSimpleName());
+
+        this.launcher.launch(getAndroidPermissions());
+
+        // Store the request in the SharedPreferences
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(SHARED_PREFERENCES_KEY, true);
+        editor.apply();
     }
 
     /**

--- a/app/src/main/java/com/example/musicmap/util/Permission.java
+++ b/app/src/main/java/com/example/musicmap/util/Permission.java
@@ -1,0 +1,203 @@
+package com.example.musicmap.util;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.activity.result.ActivityResultCaller;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.core.content.ContextCompat;
+
+import com.example.musicmap.MusicMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A utility class for dealing with runtime (i.e. dangerous) permissions.
+ */
+public abstract class Permission {
+
+    private static final String SHARED_PREFERENCES_PREFIX = "permission_";
+    private static final String SHARED_PREFERENCES_KEY = "requested";
+
+    private final List<Runnable> onChangeListeners = new ArrayList<>();
+
+    private final ActivityResultLauncher<String[]> launcher;
+    private final SharedPreferences sharedPreferences;
+
+    /**
+     * Creates a Permission instance.
+     *
+     * @param activityResultCaller an instance such as
+     *                             a {@link androidx.fragment.app.Fragment}
+     *                             or {@link androidx.appcompat.app.AppCompatActivity}.
+     */
+    protected Permission(ActivityResultCaller activityResultCaller) {
+        launcher = activityResultCaller.registerForActivityResult(
+                new ActivityResultContracts.RequestMultiplePermissions(),
+                this::onActivityResult);
+
+        String sharedPreferencesName = SHARED_PREFERENCES_PREFIX + getClass().getSimpleName().toLowerCase(Locale.ROOT);
+        sharedPreferences = MusicMap.getInstance().getSharedPreferences(sharedPreferencesName,
+                Context.MODE_PRIVATE);
+    }
+
+    protected abstract String[] getAndroidPermissions();
+
+    protected void onActivityResult(Map<String, Boolean> permissions) {
+        onChangeListeners.forEach(Runnable::run);
+    }
+
+    /**
+     * Gets the permission grant map.
+     *
+     * This map contains, for each {@link #getAndroidPermissions() permission}, a boolean
+     * indication whether that permission was granted to the app.
+     *
+     * @return the permission grant map.
+     */
+    protected Map<String, Boolean> getPermissionGrantMap() {
+        // Gets the context
+        Context context = MusicMap.getInstance().getApplicationContext();
+
+        Map<String, Boolean> permissionGrantMap = new HashMap<>();
+        for (String permission : getAndroidPermissions()) {
+            // Check if permission is granted
+            boolean granted = ContextCompat.checkSelfPermission(context, permission)
+                    == PackageManager.PERMISSION_GRANTED;
+
+            permissionGrantMap.put(permission, granted);
+        }
+
+        return permissionGrantMap;
+    }
+
+    /**
+     * Requests this permission.
+     *
+     * Feel free to use even if the permission has already been granted.
+     */
+    public void request() {
+        Log.i("MM-Permission", "Requested " + getClass().getSimpleName());
+
+        // Check if permissions were requested before
+        if (!sharedPreferences.getBoolean(SHARED_PREFERENCES_KEY, false)) {
+            this.launcher.launch(getAndroidPermissions());
+
+            // Store the request in the SharedPreferences
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            editor.putBoolean(SHARED_PREFERENCES_KEY, true);
+            editor.apply();
+        }
+    }
+
+    /**
+     * Adds a listener that will be called when this permission's status is changed,
+     * i.e. when it is granted or denied.
+     *
+     * @param runnable the runnable to run when the status changed.
+     */
+    public void onChange(Runnable runnable) {
+        onChangeListeners.add(runnable);
+    }
+
+    /**
+     * Location permissions. Includes {@code COARSE_LOCATION} and {@code FINE_LOCATION}.
+     */
+    public static class Location extends Permission {
+        private static final String FINE = Manifest.permission.ACCESS_FINE_LOCATION;
+        private static final String COARSE = Manifest.permission.ACCESS_COARSE_LOCATION;
+
+        public Location(ActivityResultCaller activityResultCaller) {
+            super(activityResultCaller);
+        }
+
+        @Override
+        public String[] getAndroidPermissions() {
+            return new String[] {COARSE, FINE};
+        }
+
+        public boolean isFineGranted() {
+            return Boolean.TRUE.equals(getPermissionGrantMap().get(FINE));
+        }
+
+        public boolean isCoarseGranted() {
+            return isFineGranted() || Boolean.TRUE.equals(getPermissionGrantMap().get(COARSE));
+        }
+
+        public boolean isNoneGranted() {
+            return !isCoarseGranted();
+        }
+    }
+
+    /**
+     * Camera permissions.
+     */
+    public static class Camera extends Permission {
+        private static final String CAMERA = Manifest.permission.CAMERA;
+
+        public Camera(ActivityResultCaller activityResultCaller) {
+            super(activityResultCaller);
+        }
+
+        @Override
+        public String[] getAndroidPermissions() {
+            return new String[] {CAMERA};
+        }
+
+        public boolean isGranted() {
+            return Boolean.TRUE.equals(getPermissionGrantMap().get(CAMERA));
+        }
+    }
+
+    /**
+     * Media permissions, includes images and video.
+     */
+    public static class Media extends Permission {
+        public Media(ActivityResultCaller activityResultCaller) {
+            super(activityResultCaller);
+        }
+
+        @Override
+        public String[] getAndroidPermissions() {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return new String[] {Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES};
+            } else {
+                return new String[] {Manifest.permission.READ_EXTERNAL_STORAGE};
+            }
+        }
+
+        public boolean isReadImagesGranted() {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return Boolean.TRUE.equals(getPermissionGrantMap().get(Manifest.permission.READ_MEDIA_IMAGES));
+            } else {
+                return Boolean.TRUE.equals(getPermissionGrantMap().get(Manifest.permission.READ_EXTERNAL_STORAGE));
+            }
+        }
+
+        public boolean isReadVideoGranted() {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return Boolean.TRUE.equals(getPermissionGrantMap().get(Manifest.permission.READ_MEDIA_VIDEO));
+            } else {
+                return Boolean.TRUE.equals(getPermissionGrantMap().get(Manifest.permission.READ_EXTERNAL_STORAGE));
+            }
+        }
+
+        public boolean isReadAllGranted() {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return isReadImagesGranted() && isReadVideoGranted();
+            } else {
+                return Boolean.TRUE.equals(getPermissionGrantMap().get(Manifest.permission.READ_EXTERNAL_STORAGE));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a utility class with the following features:
- request permissions (if not requested before)
- check if permissions have been granted (and to what extent)
- listen for permission changes

All regarding runtime (aka dangerous) permissions that give the user a pop-up to grant them