### PR TITLE
Fix layout switch bugs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <activity
             android:name=".screens.settings.SettingsActivity"
             android:exported="false"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.MusicMap.NoActionBar"/>
         <service android:name=".services.InternetCheckService" />
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
             android:exported="true"
             android:label="MusicMap"
             android:theme="@style/Theme.MusicMap.NoActionBar"
+            android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
@@ -40,13 +40,19 @@ public class ProfileActivity extends SessionAndInternetListenerActivity {
         setupActivity();
     }
 
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        startActivity(new Intent(ProfileActivity.this, HomeActivity.class));
+        finish();
+    }
+
     private void setupActivity() {
         FragmentUtil.initFragment(getSupportFragmentManager(), R.id.profileFragment, ProfilePageFragment.class);
         ImageView backButton = findViewById(R.id.appbarBack);
 
         backButton.setOnClickListener(view -> {
-            startActivity(new Intent(ProfileActivity.this, HomeActivity.class));
-            finish();
+            this.onBackPressed();
         });
 
         ImageView settingsButton = findViewById(R.id.appbarSettings);

--- a/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
@@ -57,7 +57,6 @@ public class SettingsActivity extends SessionAndInternetListenerActivity {
         }
     }
 
-
     private void setupActivity() {
         FragmentUtil.initFragment(getSupportFragmentManager(), R.id.fragmentSettings, SettingsFragment.class);
         ImageView backButton = findViewById(R.id.appbarBack);

--- a/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
@@ -6,6 +6,7 @@ import android.widget.ImageView;
 
 import com.example.musicmap.R;
 import com.example.musicmap.SessionAndInternetListenerActivity;
+import com.example.musicmap.screens.main.HomeActivity;
 import com.example.musicmap.screens.profile.ProfileActivity;
 import com.example.musicmap.util.ui.FragmentUtil;
 
@@ -40,13 +41,19 @@ public class SettingsActivity extends SessionAndInternetListenerActivity {
         setupActivity();
     }
 
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        startActivity(new Intent(SettingsActivity.this, ProfileActivity.class));
+        finish();
+    }
+
     private void setupActivity() {
         FragmentUtil.initFragment(getSupportFragmentManager(), R.id.fragmentSettings, SettingsFragment.class);
         ImageView backButton = findViewById(R.id.appbarBack);
 
         backButton.setOnClickListener(view -> {
-            startActivity(new Intent(SettingsActivity.this, ProfileActivity.class));
-            finish();
+            this.onBackPressed();
         });
     }
 

--- a/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
@@ -4,6 +4,9 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.widget.ImageView;
 
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
 import com.example.musicmap.R;
 import com.example.musicmap.SessionAndInternetListenerActivity;
 import com.example.musicmap.screens.profile.ProfileActivity;
@@ -42,10 +45,18 @@ public class SettingsActivity extends SessionAndInternetListenerActivity {
 
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
-        startActivity(new Intent(SettingsActivity.this, ProfileActivity.class));
-        finish();
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        Fragment currentFragment = fragmentManager.findFragmentById(R.id.fragmentSettings);
+
+        if (currentFragment instanceof AccountSettingsFragment) {
+            fragmentManager.popBackStack();
+        } else {
+            super.onBackPressed();
+            startActivity(new Intent(SettingsActivity.this, ProfileActivity.class));
+            finish();
+        }
     }
+
 
     private void setupActivity() {
         FragmentUtil.initFragment(getSupportFragmentManager(), R.id.fragmentSettings, SettingsFragment.class);

--- a/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
@@ -6,7 +6,6 @@ import android.widget.ImageView;
 
 import com.example.musicmap.R;
 import com.example.musicmap.SessionAndInternetListenerActivity;
-import com.example.musicmap.screens.main.HomeActivity;
 import com.example.musicmap.screens.profile.ProfileActivity;
 import com.example.musicmap.util.ui.FragmentUtil;
 


### PR DESCRIPTION
Bug fixes:
1. Inconsistent back & back button pressed actions in ProfileActivity and SettingsActivity (closes #53)
2. Feed fragment layered on map fragment with landscape orientation
3. Settings fragment layered on account settings fragment with landscape orientation