### PR TITLE
Profile for all users

### DIFF
--- a/app/src/main/java/com/example/musicmap/screens/main/HomeActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/main/HomeActivity.java
@@ -1,5 +1,7 @@
 package com.example.musicmap.screens.main;
 
+import static java.security.AccessController.getContext;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -25,6 +27,7 @@ public class HomeActivity extends SpotifyAuthActivity {
     private int currentLayout = R.layout.activity_home;
 
     private BottomNavigationView bottomNavigationView;
+    private ImageView profileButton;
 
     @Override
     protected void updateLayout(boolean internetAvailable) {
@@ -61,6 +64,7 @@ public class HomeActivity extends SpotifyAuthActivity {
     public void onSessionStateChanged() {
         User currentUser = Session.getInstance().getCurrentUser();
         updateNavbar(currentUser);
+        setupProfileButton(currentUser);
     }
 
     private void setupActivity() {
@@ -68,14 +72,10 @@ public class HomeActivity extends SpotifyAuthActivity {
         FragmentUtil.initFragment(getSupportFragmentManager(), R.id.fragment_view, lastFragmentClass);
 
         bottomNavigationView = findViewById(R.id.bottom_navigation);
-        ImageView profileButton = findViewById(R.id.appbarProfile);
-
-        profileButton.setOnClickListener(view -> {
-            startActivity(new Intent(HomeActivity.this, ProfileActivity.class));
-            finish();
-        });
+        profileButton = findViewById(R.id.appbarProfile);
 
         updateNavbar(currentUser);
+        setupProfileButton(currentUser);
 
         bottomNavigationView.setOnItemSelectedListener(item -> {
             // using ifs instead of switch as resource IDs will be non-final by default in
@@ -124,6 +124,19 @@ public class HomeActivity extends SpotifyAuthActivity {
         boolean isArtist = currentUser != null && currentUser.isArtist();
         post.setVisible(!isArtist);
         artistData.setVisible(isArtist);
+    }
+
+    private void setupProfileButton(User currentUser) {
+        if (currentUser == null || profileButton == null) {
+            return;
+        }
+
+        profileButton.setOnClickListener(view -> {
+            Intent intent = new Intent(this, ProfileActivity.class);
+            intent.putExtra("user_uid", currentUser.getUid());
+            startActivity(intent);
+            finish();
+        });
     }
 
 }

--- a/app/src/main/java/com/example/musicmap/screens/main/HomeActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/main/HomeActivity.java
@@ -14,6 +14,7 @@ import com.example.musicmap.screens.map.PostMapFragment;
 import com.example.musicmap.screens.profile.ProfileActivity;
 import com.example.musicmap.user.Session;
 import com.example.musicmap.user.User;
+import com.example.musicmap.util.Constants;
 import com.example.musicmap.util.permissions.LocationPermission;
 import com.example.musicmap.util.spotify.SpotifyAuthActivity;
 import com.example.musicmap.util.ui.FragmentUtil;
@@ -131,7 +132,7 @@ public class HomeActivity extends SpotifyAuthActivity {
 
         profileButton.setOnClickListener(view -> {
             Intent intent = new Intent(this, ProfileActivity.class);
-            intent.putExtra("user_uid", currentUser.getUid());
+            intent.putExtra(Constants.PROFILE_USER_UID_ARGUMENT, currentUser.getUid());
             startActivity(intent);
             finish();
         });

--- a/app/src/main/java/com/example/musicmap/screens/main/HomeActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/main/HomeActivity.java
@@ -1,7 +1,5 @@
 package com.example.musicmap.screens.main;
 
-import static java.security.AccessController.getContext;
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -16,8 +14,8 @@ import com.example.musicmap.screens.map.PostMapFragment;
 import com.example.musicmap.screens.profile.ProfileActivity;
 import com.example.musicmap.user.Session;
 import com.example.musicmap.user.User;
-import com.example.musicmap.util.spotify.SpotifyAuthActivity;
 import com.example.musicmap.util.permissions.LocationPermission;
+import com.example.musicmap.util.spotify.SpotifyAuthActivity;
 import com.example.musicmap.util.ui.FragmentUtil;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
@@ -43,12 +43,14 @@ public class ProfileActivity extends SessionAndInternetListenerActivity {
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        startActivity(new Intent(ProfileActivity.this, HomeActivity.class));
+        startActivity(new Intent(this, HomeActivity.class));
         finish();
     }
 
     private void setupActivity() {
-        FragmentUtil.initFragment(getSupportFragmentManager(), R.id.profileFragment, ProfilePageFragment.class);
+        FragmentUtil.initFragment(getSupportFragmentManager(), R.id.profileFragment, ProfilePageFragment.class,
+                getIntent().getExtras());
+
         ImageView backButton = findViewById(R.id.appbarBack);
 
         backButton.setOnClickListener(view -> {

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
@@ -15,6 +15,7 @@ import com.example.musicmap.util.ui.FragmentUtil;
 public class ProfileActivity extends SessionAndInternetListenerActivity {
 
     private int currentLayout = R.layout.activity_profile;
+    private Bundle currentBundle = null;
 
     @Override
     protected void updateLayout(boolean internetAvailable) {
@@ -39,6 +40,7 @@ public class ProfileActivity extends SessionAndInternetListenerActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_profile);
+        this.currentBundle = getIntent().getExtras();
         setupActivity();
     }
 
@@ -51,7 +53,7 @@ public class ProfileActivity extends SessionAndInternetListenerActivity {
 
     private void setupActivity() {
         FragmentUtil.initFragment(getSupportFragmentManager(), R.id.profileFragment, ProfilePageFragment.class,
-                getIntent().getExtras());
+                this.currentBundle);
 
         ImageView backButton = findViewById(R.id.appbarBack);
 

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
@@ -10,6 +10,7 @@ import com.example.musicmap.SessionAndInternetListenerActivity;
 import com.example.musicmap.screens.main.HomeActivity;
 import com.example.musicmap.screens.settings.SettingsActivity;
 import com.example.musicmap.user.Session;
+import com.example.musicmap.util.Constants;
 import com.example.musicmap.util.ui.FragmentUtil;
 
 public class ProfileActivity extends SessionAndInternetListenerActivity {
@@ -64,7 +65,8 @@ public class ProfileActivity extends SessionAndInternetListenerActivity {
         ImageView settingsButton = findViewById(R.id.appbarSettings);
 
         // Disable settings button if profile is for a different user
-        if (!Session.getInstance().getCurrentUser().getUid().equals(getIntent().getStringExtra("user_uid"))) {
+        if (!Session.getInstance().getCurrentUser().getUid().equals(
+                getIntent().getStringExtra(Constants.PROFILE_USER_UID_ARGUMENT))) {
             settingsButton.setVisibility(View.INVISIBLE);
         } else {
             settingsButton.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
@@ -8,11 +8,9 @@ import android.widget.ImageView;
 import com.example.musicmap.R;
 import com.example.musicmap.SessionAndInternetListenerActivity;
 import com.example.musicmap.screens.main.HomeActivity;
+import com.example.musicmap.screens.settings.SettingsActivity;
 import com.example.musicmap.user.Session;
 import com.example.musicmap.util.ui.FragmentUtil;
-import com.example.musicmap.screens.settings.SettingsActivity;
-
-import java.util.Objects;
 
 public class ProfileActivity extends SessionAndInternetListenerActivity {
 

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfileActivity.java
@@ -2,13 +2,17 @@ package com.example.musicmap.screens.profile;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.ImageView;
 
 import com.example.musicmap.R;
 import com.example.musicmap.SessionAndInternetListenerActivity;
 import com.example.musicmap.screens.main.HomeActivity;
+import com.example.musicmap.user.Session;
 import com.example.musicmap.util.ui.FragmentUtil;
 import com.example.musicmap.screens.settings.SettingsActivity;
+
+import java.util.Objects;
 
 public class ProfileActivity extends SessionAndInternetListenerActivity {
 
@@ -58,6 +62,13 @@ public class ProfileActivity extends SessionAndInternetListenerActivity {
         });
 
         ImageView settingsButton = findViewById(R.id.appbarSettings);
+
+        // Disable settings button if profile is for a different user
+        if (!Session.getInstance().getCurrentUser().getUid().equals(getIntent().getStringExtra("user_uid"))) {
+            settingsButton.setVisibility(View.INVISIBLE);
+        } else {
+            settingsButton.setVisibility(View.VISIBLE);
+        }
 
         settingsButton.setOnClickListener(view -> {
             startActivity(new Intent(this, SettingsActivity.class));

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfilePageFragment.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfilePageFragment.java
@@ -22,8 +22,6 @@ import com.example.musicmap.user.User;
 import com.example.musicmap.util.firebase.AuthSystem;
 import com.example.musicmap.util.firebase.Queries;
 import com.example.musicmap.util.ui.Message;
-import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseUser;
 import com.squareup.picasso.Picasso;
 
 import java.util.List;
@@ -68,29 +66,26 @@ public class ProfilePageFragment extends Fragment {
     }
 
     private void displayData(User user) {
-        FirebaseAuth auth = FirebaseAuth.getInstance();
-        FirebaseUser firebaseUser = auth.getCurrentUser();
-
-        if (firebaseUser != null) {
-            if (user != null) {
-                usernameTextView.setText(user.getData().getUsername());
-                if (user.getData().hasProfilePicture()) {
-                    Uri uri = user.getData().getProfilePictureUri();
-                    Picasso.get().load(uri).into(profilePicture);
-                }
-            }
-
-            Queries.getMusicMemoriesByAuthorId(firebaseUser.getUid()).addOnCompleteListener(completedTask -> {
-                if (completedTask.isSuccessful()) {
-                    List<MusicMemory> feed = completedTask.getResult();
-                    feedAdapter.addAll(feed);
-                    feedAdapter.notifyDataSetChanged();
-                } else {
-                    Log.e(TAG, "Exception occurred while getting music memories from author",
-                            completedTask.getException());
-                }
-            });
+        if (user == null) {
+            return;
         }
+
+        usernameTextView.setText(user.getData().getUsername());
+        if (user.getData().hasProfilePicture()) {
+            Uri uri = user.getData().getProfilePictureUri();
+            Picasso.get().load(uri).into(profilePicture);
+        }
+
+        Queries.getMusicMemoriesByAuthorId(user.getUid()).addOnCompleteListener(completedTask -> {
+            if (completedTask.isSuccessful()) {
+                List<MusicMemory> feed = completedTask.getResult();
+                feedAdapter.addAll(feed);
+                feedAdapter.notifyDataSetChanged();
+            } else {
+                Log.e(TAG, "Exception occurred while getting music memories from author",
+                        completedTask.getException());
+            }
+        });
     }
 
 }

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfilePageFragment.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfilePageFragment.java
@@ -19,6 +19,7 @@ import com.example.musicmap.feed.FeedAdapter;
 import com.example.musicmap.feed.MusicMemory;
 import com.example.musicmap.user.Session;
 import com.example.musicmap.user.User;
+import com.example.musicmap.util.Constants;
 import com.example.musicmap.util.firebase.AuthSystem;
 import com.example.musicmap.util.firebase.Queries;
 import com.example.musicmap.util.ui.Message;
@@ -47,10 +48,10 @@ public class ProfilePageFragment extends Fragment {
         profileListView.setAdapter(feedAdapter);
 
         Bundle args = getArguments();
-        if (args == null || args.getString("user_uid") == null) {
+        if (args == null || args.getString(Constants.PROFILE_USER_UID_ARGUMENT) == null) {
             displayData(Session.getInstance().getCurrentUser());
         } else {
-            String userUid = args.getString("user_uid");
+            String userUid = args.getString(Constants.PROFILE_USER_UID_ARGUMENT);
             AuthSystem.getUser(userUid).addOnCompleteListener(task -> {
                 if (!task.isSuccessful()) {
                     Log.e(TAG, "Exception occurred while getting user data for profile", task.getException());

--- a/app/src/main/java/com/example/musicmap/screens/profile/ProfilePageFragment.java
+++ b/app/src/main/java/com/example/musicmap/screens/profile/ProfilePageFragment.java
@@ -32,7 +32,6 @@ public class ProfilePageFragment extends Fragment {
 
     private static final String TAG = "ProfilePageFragment";
 
-    private TextView emailVerifiedTextView;
     private TextView usernameTextView;
     private ImageView profilePicture;
     private FeedAdapter feedAdapter;
@@ -41,7 +40,6 @@ public class ProfilePageFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View profileView = inflater.inflate(R.layout.fragment_profile_page, container, false);
 
-        emailVerifiedTextView = profileView.findViewById(id.emailVerified_text);
         usernameTextView = profileView.findViewById(R.id.profileUsername_textView);
         profilePicture = profileView.findViewById(id.profilePictureImage);
         ListView profileListView = profileView.findViewById(R.id.mm_list);
@@ -74,14 +72,6 @@ public class ProfilePageFragment extends Fragment {
         FirebaseUser firebaseUser = auth.getCurrentUser();
 
         if (firebaseUser != null) {
-            firebaseUser.reload().addOnCompleteListener(task -> {
-                if (!firebaseUser.isEmailVerified()) {
-                    emailVerifiedTextView.setText(getString(R.string.email_not_verified));
-                } else {
-                    emailVerifiedTextView.setText(getString(R.string.email_verified));
-                }
-            });
-
             if (user != null) {
                 usernameTextView.setText(user.getData().getUsername());
                 if (user.getData().hasProfilePicture()) {

--- a/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
@@ -10,6 +10,8 @@ import androidx.fragment.app.FragmentManager;
 import com.example.musicmap.R;
 import com.example.musicmap.SessionAndInternetListenerActivity;
 import com.example.musicmap.screens.profile.ProfileActivity;
+import com.example.musicmap.user.Session;
+import com.example.musicmap.user.User;
 import com.example.musicmap.util.ui.FragmentUtil;
 
 public class SettingsActivity extends SessionAndInternetListenerActivity {
@@ -52,7 +54,10 @@ public class SettingsActivity extends SessionAndInternetListenerActivity {
             fragmentManager.popBackStack();
         } else {
             super.onBackPressed();
-            startActivity(new Intent(SettingsActivity.this, ProfileActivity.class));
+            User currentUser = Session.getInstance().getCurrentUser();
+            Intent intent = new Intent(this, ProfileActivity.class);
+            intent.putExtra("user_uid", currentUser.getUid());
+            startActivity(intent);
             finish();
         }
     }

--- a/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/musicmap/screens/settings/SettingsActivity.java
@@ -12,6 +12,7 @@ import com.example.musicmap.SessionAndInternetListenerActivity;
 import com.example.musicmap.screens.profile.ProfileActivity;
 import com.example.musicmap.user.Session;
 import com.example.musicmap.user.User;
+import com.example.musicmap.util.Constants;
 import com.example.musicmap.util.ui.FragmentUtil;
 
 public class SettingsActivity extends SessionAndInternetListenerActivity {
@@ -56,7 +57,7 @@ public class SettingsActivity extends SessionAndInternetListenerActivity {
             super.onBackPressed();
             User currentUser = Session.getInstance().getCurrentUser();
             Intent intent = new Intent(this, ProfileActivity.class);
-            intent.putExtra("user_uid", currentUser.getUid());
+            intent.putExtra(Constants.PROFILE_USER_UID_ARGUMENT, currentUser.getUid());
             startActivity(intent);
             finish();
         }

--- a/app/src/main/java/com/example/musicmap/util/Constants.java
+++ b/app/src/main/java/com/example/musicmap/util/Constants.java
@@ -15,4 +15,6 @@ public final class Constants {
      */
     public static final String INTERNET_BROADCAST_BUNDLE_KEY = "available";
 
+    public static final String PROFILE_USER_UID_ARGUMENT = "user_uid";
+
 }

--- a/app/src/main/java/com/example/musicmap/util/ui/FragmentUtil.java
+++ b/app/src/main/java/com/example/musicmap/util/ui/FragmentUtil.java
@@ -1,7 +1,10 @@
 package com.example.musicmap.util.ui;
 
+import android.os.Bundle;
+
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
@@ -21,8 +24,23 @@ public class FragmentUtil {
     public static void initFragment(@NonNull FragmentManager fragmentManager,
                                     @IdRes int containerID,
                                     @NonNull Class<? extends Fragment> fragmentClass) {
+        initFragment(fragmentManager, containerID, fragmentClass, null);
+    }
+
+    /**
+     * This method initializes the given container with the given fragment class.
+     *
+     * @param fragmentManager the given Fragment Manager
+     * @param containerID     the id of the container
+     * @param fragmentClass   the class of the fragment
+     * @param args            the arguments for the fragment
+     */
+    public static void initFragment(@NonNull FragmentManager fragmentManager,
+                                    @IdRes int containerID,
+                                    @NonNull Class<? extends Fragment> fragmentClass,
+                                    @Nullable Bundle args) {
         fragmentManager.beginTransaction().setReorderingAllowed(true).add(containerID,
-                fragmentClass, null).commit();
+                fragmentClass, args).commit();
     }
 
     /**

--- a/app/src/main/res/layout/fragment_profile_page.xml
+++ b/app/src/main/res/layout/fragment_profile_page.xml
@@ -2,7 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/d"
+    android:id="@+id/profileFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".screens.profile.ProfilePageFragment">
@@ -43,18 +43,6 @@
                 app:layout_constraintStart_toEndOf="@+id/profilePictureImage"
                 app:layout_constraintTop_toTopOf="@+id/profilePictureImage" />
 
-            <TextView
-                android:id="@+id/emailVerified_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
-                android:fontFamily="@font/inter"
-                android:textSize="16sp"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/profilePictureImage"
-                app:layout_constraintTop_toBottomOf="@+id/profileUsername_textView" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <View


### PR DESCRIPTION
Makes the profile screen support users besides the current user too. For profile pages of other users, the settings button is hidden. Added a utility method to FragmentUtil for initFragment but with arguments. Removed the email verification text from the profile activity (not from strings, they can be reused for that requirement).

Use the following to launch profile screen for a certain user:
```java
Intent intent = new Intent(getContext(), ProfileActivity.class);
intent.putExtra("user_uid", userUid);
startActivity(intent);
```