### PR TITLE
Fix NPE when spamming between map and feed

### DIFF
--- a/app/src/main/java/com/example/musicmap/screens/map/PostMapFragment.java
+++ b/app/src/main/java/com/example/musicmap/screens/map/PostMapFragment.java
@@ -46,6 +46,11 @@ public class PostMapFragment extends MapFragment {
 
         // Start fetching music memories
         Queries.getAllMusicMemoriesInLastTwentyFourHours().addOnCompleteListener(completedTask -> {
+            if (postsFolder.getItems() == null) {
+                // View no longer active
+                return;
+            }
+
             if (completedTask.isSuccessful()) {
                 // Add all retrieved music memories to map
                 completedTask.getResult().stream()

--- a/app/src/main/java/com/example/musicmap/screens/map/PostMapFragment.java
+++ b/app/src/main/java/com/example/musicmap/screens/map/PostMapFragment.java
@@ -47,7 +47,7 @@ public class PostMapFragment extends MapFragment {
         // Start fetching music memories
         Queries.getAllMusicMemoriesInLastTwentyFourHours().addOnCompleteListener(completedTask -> {
             if (postsFolder.getItems() == null) {
-                // View no longer active
+                // Overlay got detached
                 return;
             }
 


### PR DESCRIPTION
Stacktrace: https://pastebin.com/3MZQbpyU

Caused by the query of the map requesting music memories being finished when the map is already hidden again (app switched to the feed), where some variable is set to null when the overlay is detached, FolderOverlay:
![image](https://user-images.githubusercontent.com/29547183/230363497-0c0ea8db-85dd-4def-91dd-6d5d34ce5f0a.png)

I looked for a better way to check if this thing is detached, couldn't find it. There might still be one, I could check again in week 9+10