### PR TITLE
Added checks if token has actually expired

### DIFF
--- a/app/src/main/java/com/example/musicmap/util/spotify/SpotifyAuthActivity.java
+++ b/app/src/main/java/com/example/musicmap/util/spotify/SpotifyAuthActivity.java
@@ -46,34 +46,36 @@ public abstract class SpotifyAuthActivity extends SessionAndInternetListenerActi
     }
 
     public void refreshToken(ValidTokenCallback validTokenCallback, InvalidTokenCallback invalidTokenCallback) {
+        if (SpotifyData.tokenIsExpired()) {
+            String currentUserId = Session.getInstance().getCurrentUser().getUid();
+            FirebaseTokenStorage tokenStorage = new FirebaseTokenStorage(currentUserId);
 
-        String currentUserId = Session.getInstance().getCurrentUser().getUid();
-        FirebaseTokenStorage tokenStorage = new FirebaseTokenStorage(currentUserId);
+            tokenStorage.getRefreshToken(refreshToken -> {
 
-        tokenStorage.getRefreshToken(refreshToken -> {
-            
-            if (refreshToken == null) {
-                invalidTokenCallback.onInvalidToken();
-                return;
-            }
-
-            loginApi.setRefreshToken(refreshToken);
-            loginApi.authorizationCodePKCERefresh().build().executeAsync().handle((refreshResult, error) -> {
-                if (error != null) {
-                    Log.d(TAG, String.format("error %s", error.getMessage()));
+                if (refreshToken == null) {
                     invalidTokenCallback.onInvalidToken();
-                    return null;
+                    return;
                 }
 
-                return refreshResult;
-            }).thenAccept(refreshResult -> {
-                Log.d(TAG, "The Spotify token was successfully refreshed!");
+                loginApi.setRefreshToken(refreshToken);
+                loginApi.authorizationCodePKCERefresh().build().executeAsync().handle((refreshResult, error) -> {
+                    if (error != null) {
+                        Log.d(TAG, String.format("error %s", error.getMessage()));
+                        invalidTokenCallback.onInvalidToken();
+                        return null;
+                    }
 
-                tokenStorage.storeRefreshToken(refreshResult.getRefreshToken());
-                SpotifyData.setToken(refreshResult.getAccessToken());
-                validTokenCallback.onValidToken(refreshResult.getAccessToken());
+                    return refreshResult;
+                }).thenAccept(refreshResult -> {
+                    Log.d(TAG, "The Spotify token was successfully refreshed!");
+                    Log.d(TAG, String.format("ExpiryDate: %d", refreshResult.getExpiresIn()));
+
+                    tokenStorage.storeRefreshToken(refreshResult.getRefreshToken());
+                    SpotifyData.setToken(refreshResult.getAccessToken(), refreshResult.getExpiresIn());
+                    validTokenCallback.onValidToken(refreshResult.getAccessToken());
+                });
             });
-        });
+        }
     }
 
     public void registerForSpotifyPKCE() {
@@ -142,10 +144,11 @@ public abstract class SpotifyAuthActivity extends SessionAndInternetListenerActi
                         Log.d(TAG, String.format("Token type: %s", authCredentials.getTokenType()));
                         Log.d(TAG, String.format("RefreshToken: %s", authCredentials.getRefreshToken()));
 
-                        // TODO updateFirebase
                         String currentUserId = Session.getInstance().getCurrentUser().getUid();
                         FirebaseTokenStorage tokenStorage = new FirebaseTokenStorage(currentUserId);
                         tokenStorage.storeRefreshToken(authCredentials.getRefreshToken());
+                        SpotifyData.setToken(authCredentials.getAccessToken(), authCredentials.getExpiresIn());
+
                     }
             );
         }

--- a/app/src/main/java/com/example/musicmap/util/spotify/SpotifyData.java
+++ b/app/src/main/java/com/example/musicmap/util/spotify/SpotifyData.java
@@ -17,14 +17,21 @@ public class SpotifyData {
 
     private static String token = null;
     private static SpotifyApi spotifyApi;
+    private static long tokenExpiryTimeStampMillis = -1; // the time the token expires in milliseconds
 
-    public static void setToken(String inputToken) {
+    public static void setToken(String inputToken, long expiryTimeSeconds) {
         token = inputToken;
         spotifyApi = new SpotifyApi.Builder()
                 .setAccessToken(token)
                 .build();
-
+        final int EARLIER_REFRESH_TIME_SECONDS = 300;
+        long expiryTimeMillis = (expiryTimeSeconds - EARLIER_REFRESH_TIME_SECONDS) * 1000;
+        tokenExpiryTimeStampMillis = System.currentTimeMillis() +  expiryTimeMillis;
         Log.d("debug", String.format("[poop] token recieved %s", token));
+    }
+
+    public static boolean tokenIsExpired() {
+        return tokenExpiryTimeStampMillis < System.currentTimeMillis();
     }
 
     public static String getToken() {


### PR DESCRIPTION
Actually checks if a spotify access token needs to be refreshed. If it does not then it does nothing (AMAZING!). This prevents a bug where spotify would ask for reauthentication