### PR TITLE
Actions cleanup

### DIFF
--- a/app/src/main/java/com/groupseven/musicmap/screens/main/musicmemory/create/PostFragment.java
+++ b/app/src/main/java/com/groupseven/musicmap/screens/main/musicmemory/create/PostFragment.java
@@ -329,13 +329,12 @@ public class PostFragment extends MainFragment {
                 SearchFragment.getResultTrack().getPreviewUrl()
         );
 
-        Actions.uploadMusicMemoryImage(capturedImage, authorID).addOnCompleteListener(task -> {
-            String imageUrl = task.getResult().toString();
+        Actions.uploadMusicMemoryImage(capturedImage, authorID).thenAccept(imageUrl -> {
             Actions.postMusicMemory(new MusicMemory(
                     authorID,
                     timePosted,
                     geoPointLocation,
-                    imageUrl,
+                    imageUrl.toString(),
                     song
             )).whenCompleteAsync((unused, throwable) -> {
                 if (throwable != null) {

--- a/app/src/main/java/com/groupseven/musicmap/screens/main/musicmemory/create/PostFragment.java
+++ b/app/src/main/java/com/groupseven/musicmap/screens/main/musicmemory/create/PostFragment.java
@@ -337,19 +337,21 @@ public class PostFragment extends MainFragment {
                     geoPointLocation,
                     imageUrl,
                     song
-            )).addOnFailureListener(e -> {
-                Message.showFailureMessage(this.currentActivity, "Could not create the music memory");
-                postMemoryButton.setEnabled(true);
-            }).addOnCompleteListener(unused -> {
-                        clearData();
-                        FragmentUtil.replaceFragment(
-                                requireActivity().getSupportFragmentManager(),
-                                R.id.fragment_view,
-                                FeedFragment.class
-                        );
-                        Message.showSuccessMessage(this.currentActivity, "Successfully created the music memory");
-                    }
-            );
+            )).whenCompleteAsync((unused, throwable) -> {
+                if (throwable != null) {
+                    Log.e(TAG, "Could not create music memory", throwable);
+                    Message.showFailureMessage(this.currentActivity, "Could not create the music memory");
+                    postMemoryButton.setEnabled(true);
+                } else {
+                    clearData();
+                    FragmentUtil.replaceFragment(
+                            requireActivity().getSupportFragmentManager(),
+                            R.id.fragment_view,
+                            FeedFragment.class
+                    );
+                    Message.showSuccessMessage(this.currentActivity, "Successfully created the music memory");
+                }
+            }, ContextCompat.getMainExecutor(requireContext()));
         });
     }
 

--- a/app/src/main/java/com/groupseven/musicmap/screens/main/musicmemory/create/PostFragment.java
+++ b/app/src/main/java/com/groupseven/musicmap/screens/main/musicmemory/create/PostFragment.java
@@ -235,7 +235,7 @@ public class PostFragment extends MainFragment {
     @SuppressLint("MissingPermission")
     private void fetchUserLocation() {
         if (fusedLocationClient == null) {
-            Message.showFailureMessage(currentActivity, "Google Play services is required");
+            Message.showFailureMessage(currentActivity, getString(R.string.gps_required));
             return;
         }
 
@@ -255,7 +255,7 @@ public class PostFragment extends MainFragment {
                         Log.e(TAG, "Could not fetch user location", exception);
                     });
         } else {
-            Message.showFailureMessage(this.currentActivity, "Permission not granted for location");
+            Message.showFailureMessage(this.currentActivity, getString(R.string.location_permission_not_granted));
         }
     }
 
@@ -298,17 +298,17 @@ public class PostFragment extends MainFragment {
 
     private void postMusicMemory() {
         if (SearchFragment.getResultTrack() == null) {
-            Message.showFailureMessage(this.currentActivity, "A track is required to post a music memory!");
+            Message.showFailureMessage(this.currentActivity, getString(R.string.create_mm_track_required));
             return;
         }
 
         if (currentLocation == null) {
-            Message.showFailureMessage(this.currentActivity, "Location is required to post a music memory!");
+            Message.showFailureMessage(this.currentActivity, getString(R.string.create_mm_location_required));
             return;
         }
 
         if (capturedImage == null) {
-            Message.showFailureMessage(this.currentActivity, "An image is required to post a music memory!");
+            Message.showFailureMessage(this.currentActivity, getString(R.string.create_mm_image_required));
             return;
         }
 
@@ -339,7 +339,7 @@ public class PostFragment extends MainFragment {
             )).whenCompleteAsync((unused, throwable) -> {
                 if (throwable != null) {
                     Log.e(TAG, "Could not create music memory", throwable);
-                    Message.showFailureMessage(this.currentActivity, "Could not create the music memory");
+                    Message.showFailureMessage(this.currentActivity, getString(R.string.create_mm_failure));
                     postMemoryButton.setEnabled(true);
                 } else {
                     clearData();
@@ -348,7 +348,7 @@ public class PostFragment extends MainFragment {
                             R.id.fragment_view,
                             FeedFragment.class
                     );
-                    Message.showSuccessMessage(this.currentActivity, "Successfully created the music memory");
+                    Message.showSuccessMessage(this.currentActivity, getString(R.string.create_mm_success));
                 }
             }, ContextCompat.getMainExecutor(requireContext()));
         });

--- a/app/src/main/java/com/groupseven/musicmap/util/firebase/Actions.java
+++ b/app/src/main/java/com/groupseven/musicmap/util/firebase/Actions.java
@@ -6,21 +6,19 @@ import android.util.Log;
 
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
-import com.google.firebase.storage.ListResult;
 import com.google.firebase.storage.StorageReference;
-import com.google.firebase.storage.UploadTask;
 import com.groupseven.musicmap.models.MusicMemory;
 import com.groupseven.musicmap.util.TaskUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 
+/**
+ * Actions for interacting with the Firebase server.
+ */
 public class Actions {
 
     private static final String TAG = "Actions";

--- a/app/src/main/java/com/groupseven/musicmap/util/firebase/Actions.java
+++ b/app/src/main/java/com/groupseven/musicmap/util/firebase/Actions.java
@@ -103,5 +103,5 @@ public class Actions {
             }
         }
     }
-    
+
 }

--- a/app/src/main/java/com/groupseven/musicmap/util/firebase/Actions.java
+++ b/app/src/main/java/com/groupseven/musicmap/util/firebase/Actions.java
@@ -4,17 +4,22 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.Log;
 
-import com.groupseven.musicmap.models.MusicMemory;
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.ListResult;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
+import com.groupseven.musicmap.models.MusicMemory;
 import com.groupseven.musicmap.util.TaskUtil;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class Actions {
 
@@ -48,22 +53,58 @@ public class Actions {
      * @return a future containing a {@link Uri} for downloading the image.
      */
     public static CompletableFuture<Uri> uploadMusicMemoryImage(Bitmap capturedImage, String authorUid) {
+        // Convert the image to JPEG
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         capturedImage.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
         byte[] data = outputStream.toByteArray();
 
+        // Store the JPEG image under the author UID with a random UUID
         StorageReference rootReference = FirebaseStorage.getInstance().getReference();
-        String uuid = UUID.randomUUID().toString();
-        StorageReference imageRef = rootReference.child(String.format("users/%s/memories/%s.jpg", authorUid, uuid));
-        UploadTask uploadTask = imageRef.putBytes(data);
 
-        return TaskUtil.getFuture(uploadTask)
-                .thenCompose(unused -> TaskUtil.getFuture(imageRef.getDownloadUrl()))
-                .whenComplete((url, throwable) -> {
-                    if (throwable != null) {
-                        Log.e(TAG, "Could not upload the image", throwable);
+        // Run the whole thing on a separate thread, so we can simply wait for a task to be done
+        return CompletableFuture.supplyAsync(() -> {
+            // Generate a path in the storage that does not exist already (avoid collisions)
+            StorageReference imageRef;
+            boolean pathExists;
+            do {
+                // Generate a random UUID and form the storage path with it
+                String uuid = UUID.randomUUID().toString();
+                imageRef = rootReference.child(String.format("users/%s/memories/%s.jpg", authorUid, uuid));
+
+                Log.d(TAG, "Checking if image '" + imageRef.getPath() + "' exists");
+
+                /*
+                Firebase storage doesn't have a way to check if a StorageReference exists, see
+                https://github.com/flutter/flutter/issues/18315
+
+                Therefore, try to get the download url and catch the exception if the path doesn't exist.
+
+                This will still print an exception to console each time it finds a path that doesn't exist,
+                but at least it avoids collisions.
+                 */
+                try {
+                    TaskUtil.getFuture(imageRef.getDownloadUrl()).join();
+
+                    pathExists = true;
+                } catch (CompletionException e) {
+                    // If we get an exception other than the expected one, we should still fail
+                    if (!(e.getCause() instanceof IOException)) {
+                        throw e;
                     }
-                });
+
+                    Log.w(TAG, "You can ignore the exception above, this is expected behavior; "
+                            + "see Actions#uploadMusicMemoryImage");
+                    pathExists = false;
+                }
+            } while (pathExists);
+
+            // Start uploading and get download url
+            Log.d(TAG, "Started uploading image (" + data.length + " bytes)");
+            TaskUtil.getFuture(imageRef.putBytes(data)).join();
+            Log.d(TAG, "Uploading image");
+
+            return TaskUtil.getFuture(imageRef.getDownloadUrl()).join();
+        });
     }
 
 }

--- a/app/src/main/res/values/error_strings.xml
+++ b/app/src/main/res/values/error_strings.xml
@@ -22,4 +22,11 @@
     <string name="no_internet_error">Oops! MusicMap requires an active internet connection to function. We\'re tying to find a connection</string>
     <string name="error_spotify_not_connected">We could not detect a connection to your Spotify account.</string>
     <string name="spotify_already_connected">Your spotify account is already connected!</string>
+    <string name="location_permission_not_granted">Permission not granted for location</string>
+    <string name="gps_required">Google Play services is required</string>
+    <string name="create_mm_track_required">A track is required to post a music memory!</string>
+    <string name="create_mm_location_required">Location is required to post a music memory!</string>
+    <string name="create_mm_image_required">An image is required to post a music memory!</string>
+    <string name="create_mm_failure">Could not create the music memory</string>
+    <string name="create_mm_success">Successfully created the music memory</string>
 </resources>


### PR DESCRIPTION
Cleans up actions. Converted return types to future instead of task (and usages of the methods).

Added a do-while check for uploading images, to avoid collisions in the random UUIDs. This was a pain in the ass, cause Firebase storage doesn't have a way to check if a StorageReference exists.