### PR TITLE
Network change listener fixes

### DIFF
--- a/app/src/androidTest/java/com/groupseven/musicmap/listeners/NetworkChangeListenerTest.java
+++ b/app/src/androidTest/java/com/groupseven/musicmap/listeners/NetworkChangeListenerTest.java
@@ -45,14 +45,5 @@ public class NetworkChangeListenerTest {
         assertFalse(networkChangeListener.isConnected());
     }
 
-    @Test
-    public void testIsConnected() {
-        networkChangeListener.onAvailable(mockNetwork);
-        assertTrue(networkChangeListener.isConnected());
-
-        networkChangeListener.onLost(mockNetwork);
-        assertFalse(networkChangeListener.isConnected());
-    }
-
 }
 

--- a/app/src/main/java/com/groupseven/musicmap/util/network/NetworkUtils.java
+++ b/app/src/main/java/com/groupseven/musicmap/util/network/NetworkUtils.java
@@ -25,7 +25,8 @@ public class NetworkUtils {
             NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(
                     connectivityManager.getActiveNetwork());
             return capabilities != null
-                    && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+                    && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
         }
 
         return false;


### PR DESCRIPTION
- Remove redundant and flaky tests
- Add `NET_CAPABILITY_VALIDATED` to `isInternetConnectionAvailable()`